### PR TITLE
fix url typos: marcomaggi.github.com ==> marcomaggi.github.io

### DIFF
--- a/docs/mmux-removable-media-utilities.html
+++ b/docs/mmux-removable-media-utilities.html
@@ -1513,7 +1513,7 @@ Up:&nbsp;<a rel="up" accesskey="u" href="#Top">Top</a>
 
 <p>The documentation of MMUX Removable Media Utilities is available online:
 
-<div align="center"><a href="http://marcomaggi.github.com/docs/mmux-removable-media-utilities.html">http://marcomaggi.github.com/docs/mmux-removable-media-utilities.html</a></div>
+<div align="center"><a href="https://marcomaggi.github.io/docs/mmux-removable-media-utilities.html">https://marcomaggi.github.io/docs/mmux-removable-media-utilities.html</a></div>
 
 <p class="noindent">the latest version of this package can be downloaded from:
 

--- a/docs/mmux-unsafe-users-management.html
+++ b/docs/mmux-unsafe-users-management.html
@@ -1759,7 +1759,7 @@ Up:&nbsp;<a rel="up" accesskey="u" href="#Top">Top</a>
 
 <p>The documentation of MMUX Unsafe Users Management is available online:
 
-<div align="center"><a href="http://marcomaggi.github.com/docs/mmux-unsafe-users-management.html">http://marcomaggi.github.com/docs/mmux-unsafe-users-management.html</a></div>
+<div align="center"><a href="https://marcomaggi.github.io/docs/mmux-unsafe-users-management.html">https://marcomaggi.github.io/docs/mmux-unsafe-users-management.html</a></div>
 
 <p class="noindent">the latest version of this package can be downloaded from:
 

--- a/docs/vicare-libesmtp.html
+++ b/docs/vicare-libesmtp.html
@@ -3679,7 +3679,7 @@ Next: <a href="#concept-index" accesskey="n" rel="next">concept index</a>, Previ
 
 <p>The documentation of Vicare/libESMTP is available online:
 </p>
-<div align="center"><a href="http://marcomaggi.github.com/docs/vicare-libesmtp.html">http://marcomaggi.github.com/docs/vicare-libesmtp.html</a>
+<div align="center"><a href="https://marcomaggi.github.io/docs/vicare-libesmtp.html">https://marcomaggi.github.io/docs/vicare-libesmtp.html</a>
 </div>
 <p>the latest version of this package can be downloaded from:
 </p>

--- a/docs/vicare-scheme.html/overview-resources.html
+++ b/docs/vicare-scheme.html/overview-resources.html
@@ -120,7 +120,7 @@ General Public License (<acronym>GPL</acronym>) and can be downloaded from:
 </div>
 <p>the home page of the project is at:
 </p>
-<div align="center"><a href="http://marcomaggi.github.com/vicare.html">http://marcomaggi.github.com/vicare.html</a>
+<div align="center"><a href="https://marcomaggi.github.io/vicare.html">https://marcomaggi.github.io/vicare.html</a>
 </div>
 <p>development takes place at:
 </p>

--- a/mbfl.html
+++ b/mbfl.html
@@ -67,7 +67,7 @@ them with success in implementing non-small scripts.
 <p>The latest revision is available from the GitHub
 <a href="http://github.com/marcomaggi/mbfl/">project page</a>, while stable and beta
 releases can be downloaded from the <a href="https://bitbucket.org/marcomaggi//downloads">download page</a>.  The documentation for the latest stable release is
-<a href="http://marcomaggi.github.com/docs/mbfl.html">online</a>.
+<a href="https://marcomaggi.github.io/docs/mbfl.html">online</a>.
 </p>
 <span id="License"></span><h4 class="subsubheading">License</h4>
 


### PR DESCRIPTION
The site is hosted at:

    https://marcomaggi.github.io

not at:

    http://marcomaggi.github.com

so the hyperlinks fixed here prevent HTTP 404 ("Not Found") errors when following them to a non-existent location.

Note that we change the URL scheme from 'http' to 'https', where necessary, as well.

Motivation: 404 encountered while following the 'online' link of "The documentation for the latest stable release is online." at:

    https://marcomaggi.github.io/mbfl.html